### PR TITLE
Move certificate loading logic to Certificate class & update namespace

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,7 @@ return PhpCsFixer\Config::create()
         'concat_space' => ['spacing' => 'none'],
         'declare_strict_types' => true,
         'method_separation' => true,
+        'native_function_invocation' => ['include' => ['@all'], 'strict' => false],
         'no_blank_lines_after_class_opening' => true,
         'no_spaces_around_offset' => ['positions' => ['inside', 'outside']],
         'no_unneeded_control_parentheses' => true,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ More info at [Knox Cloud API Integration Guide](https://docs.samsungknox.com/clo
 ### Sign your Client Identifier
 
 ```php
-use Proget\KnoxToken;
+use Proget\Samsung\KnoxToken\KnoxToken;
 
 $clientIdentifierJwt = KnoxToken::signClientIdentifier('your-client-identifier', 'keys.json');
 ```
@@ -23,7 +23,7 @@ $clientIdentifierJwt = KnoxToken::signClientIdentifier('your-client-identifier',
 ### Sign your Access Token
 
 ```php
-use Proget\KnoxToken;
+use Proget\Samsung\KnoxToken\KnoxToken;
 
 $accessTokenJwt = KnoxToken::signAccessToken('access-token', 'keys.json');
 ```
@@ -31,9 +31,9 @@ $accessTokenJwt = KnoxToken::signAccessToken('access-token', 'keys.json');
 ### Load certificate
 
 ```php
-use Proget\KnoxToken;
+use Proget\Samsung\KnoxToken\Certificate;
 
-$certificate = KnoxToken::loadCertificate('keys.json');
+$certificate = Certificate::fromPath('keys.json');
 
 $certificate->publicKey();
 $certificate->privateKeyPem();

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     ],
     "autoload": {
         "psr-4": {
-            "Proget\\": "src/"
+            "Proget\\Samsung\\KnoxToken\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Proget\\Tests\\": "tests/"
+            "Proget\\Tests\\Samsung\\KnoxToken\\": "tests/"
         }
     },
     "scripts": {

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Proget;
+namespace Proget\Samsung\KnoxToken;
 
 class Certificate
 {
@@ -20,6 +20,20 @@ class Certificate
     {
         $this->publicKey = $publicKey;
         $this->privateKey = $privateKey;
+    }
+
+    public static function fromPath(string $certificatePath): Certificate
+    {
+        if (!\file_exists($certificatePath)) {
+            throw new \RuntimeException(\sprintf('Missing certificate file at %s', $certificatePath));
+        }
+
+        $certificate = \json_decode(\file_get_contents($certificatePath), true);
+        if (!isset($certificate['Public'], $certificate['Private'])) {
+            throw new \RuntimeException(\sprintf('Invalid certificate file at %s', $certificatePath));
+        }
+
+        return new Certificate($certificate['Public'], $certificate['Private']);
     }
 
     public function publicKey(): string

--- a/src/KnoxToken.php
+++ b/src/KnoxToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Proget;
+namespace Proget\Samsung\KnoxToken;
 
 use Firebase\JWT\JWT;
 use Ramsey\Uuid\Uuid;
@@ -13,7 +13,7 @@ class KnoxToken
 
     public static function signClientIdentifier(string $clientIdentifier, string $certificatePath): string
     {
-        $certificate = self::loadCertificate($certificatePath);
+        $certificate = Certificate::fromPath($certificatePath);
 
         return JWT::encode([
             'clientIdentifier' => $clientIdentifier,
@@ -25,7 +25,7 @@ class KnoxToken
 
     public static function signAccessToken(string $accessToken, string $certificatePath): string
     {
-        $certificate = self::loadCertificate($certificatePath);
+        $certificate = Certificate::fromPath($certificatePath);
 
         return JWT::encode([
             'accessToken' => $accessToken,
@@ -33,19 +33,5 @@ class KnoxToken
             'aud' => self::AUDIENCE,
             'jti' => Uuid::uuid1()->toString().Uuid::uuid1()->toString()
         ], $certificate->privateKeyPem(), 'RS512');
-    }
-
-    public static function loadCertificate(string $certificatePath): Certificate
-    {
-        if (!file_exists($certificatePath)) {
-            throw new \RuntimeException(sprintf('Missing certificate file at %s', $certificatePath));
-        }
-        $certificate = json_decode(file_get_contents($certificatePath), true);
-
-        if (!isset($certificate['Public'], $certificate['Private'])) {
-            throw new \RuntimeException(sprintf('Invalid certificate file at %s', $certificatePath));
-        }
-
-        return new Certificate($certificate['Public'], $certificate['Private']);
     }
 }

--- a/tests/CertificateTest.php
+++ b/tests/CertificateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Proget\Tests\Samsung\KnoxToken;
+
+use PHPUnit\Framework\TestCase;
+use Proget\Samsung\KnoxToken\Certificate;
+
+class CertificateTest extends TestCase
+{
+    public function testLoad(): void
+    {
+        $certificate = Certificate::fromPath(__DIR__.'/keys.json');
+
+        self::assertEquals(204, \strlen($certificate->publicKey()));
+        self::assertEquals(886, \strlen($certificate->privateKeyPem()));
+    }
+
+    public function testLoadFromInvalidPath(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Missing certificate file at /some/invalid/path');
+
+        Certificate::fromPath('/some/invalid/path');
+    }
+
+    public function testLoadFromInvalidFile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid certificate file at '.__FILE__);
+
+        Certificate::fromPath(__FILE__);
+    }
+}

--- a/tests/KnoxTokenTest.php
+++ b/tests/KnoxTokenTest.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Proget\Tests;
+namespace Proget\Tests\Samsung\KnoxToken;
 
 use PHPUnit\Framework\TestCase;
-use Proget\Certificate;
-use Proget\KnoxToken;
+use Proget\Samsung\KnoxToken\KnoxToken;
 
 class KnoxTokenTest extends TestCase
 {
     public function testSignClientIdentifier(): void
     {
-        self::assertEquals(713, strlen(KnoxToken::signClientIdentifier(
+        self::assertEquals(713, \strlen(KnoxToken::signClientIdentifier(
             'a33a7593-dbaf-457f-87be-19243a421aec',
             __DIR__.'/keys.json'
         )));
@@ -20,34 +19,9 @@ class KnoxTokenTest extends TestCase
 
     public function testSignAccessToken(): void
     {
-        self::assertEquals(707, strlen(KnoxToken::signAccessToken(
+        self::assertEquals(707, \strlen(KnoxToken::signAccessToken(
             'd13d112e-8e77-4243-b795-ed4e1cf15cf9',
             __DIR__.'/keys.json'
         )));
-    }
-
-    public function testLoadCertificate(): void
-    {
-        $certificate = KnoxToken::loadCertificate(__DIR__.'/keys.json');
-
-        self::assertInstanceOf(Certificate::class, $certificate);
-        self::assertEquals(204, strlen($certificate->publicKey()));
-        self::assertEquals(886, strlen($certificate->privateKeyPem()));
-    }
-
-    public function testLoadCertificateInvalidPath(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Missing certificate file at /some/invalid/path');
-
-        KnoxToken::signAccessToken('access-token', '/some/invalid/path');
-    }
-
-    public function testLoadCertificateInvalidFile(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Invalid certificate file at '.__FILE__);
-
-        KnoxToken::signAccessToken('access-token', __FILE__);
     }
 }


### PR DESCRIPTION
Taking suggestions on other namespace possibilites. 🤓

Also, IMHO, we should make KnoxToken certificate methods accept Certificate object, not an actual path to one.